### PR TITLE
Scrape a Mesos Master process

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,54 @@ Name                           | Description
 -------------------------------|------------
 web.listen-address             | Address to listen on for web interface and telemetry.
 web.telemetry-path             | Path under which to expose metrics.
-exporter.discovery             | Enable auto disovery of elected master and active slaves.
-exporter.discovery.master-url  | URL to a Mesos master.
-exporter.local-url             | URL to the local slave if not using discovery.
-exporter.interval              | Interval at which to fetch the Mesos slave metrics.
+exporter.discover-interval     | Interval at which to update available slaves from a Mesos Master. Only used if exporter.scrape-mode=discover.
+exporter.interval              | Interval at which to fetch the Mesos slave metrics. Only used if exporter.scrape-mode=discover.
+exporter.scrape-mode           | The mode in which to run the exporter: 'discover', 'master' or 'slave'.
+exporter.url                   | The URL of a Mesos Slave, if exporter.scrape-mode=slave. The URL of a Mesos Master, if exporter.scrape-mode=discover or exporter.scrape-mode=master.
 log.level                      | Only log messages with the given severity or above. Valid levels: debug, info, warn, error, fatal, panic.
 
+### Scrape Modes
 
-### Modes
-mesos_exporter can operate in two modes: discovery and local.
+mesos_exporter can operate in three different modes: `discover`, `master` or `slave`.
+The scrape mode is specified by setting the flag `-exporter.scrape-mode=<MODE>`.
 
-In local mode only the IP specified with the commandline flag `-exporter.local-address` will be queried and exported.
-This mode is to facilitate having one exporter per Mesos slave.
+#### discover
 
-In discovery mode the Mesos slaves are discovered using the `-exporter.discovery.master` flag. The exporter will fetch
-all slave metrics and export them. 
-This mode lets you have one exporter per Mesos cluster.
+Scrape metrics of tasks running on Mesos Slaves exposed via the `/monitor/statistics.json` endpoint as well as metrics
+exposed by each Mesos Slave itself via the `/metrics/snapshot` endpoint.
 
+mesos_exporter will periodically call a Mesos Master to discover newly registered Mesos Slaves and remove Mesos Slaves
+that have deregistered.
+
+**Note:** When starting mesos_exporter in this mode, the process can run anywhere and does not need to run alongside a
+Mesos Master process.
+
+##### Example
+
+    ./mesos_exporter -exporter.discover-interval=60s -exporter.interval=15s -exporter.scrape-mode=discover -exporter.url=http://mesos.master:5050
+
+#### master
+
+Scrape metrics exposed by one Mesos Master via the `/metrics/snapshot` endpoint and the `/master/state.json` endpoint.
+
+**Note:** When starting mesos_exporter in this mode, the process should run on the same node as the Mesos Master it
+queries.
+
+##### Example
+
+    ./mesos_exporter -exporter.scrape-mode=master -exporter.url=http://127.0.0.1:5050
+
+#### slave
+
+Scrape metrics of tasks running on one Mesos Slave (via the `/monitor/statistics.json` endpoint) as well as metrics
+exposed by the Mesos Slave itself via the `/metrics/snapshot` endpoint.
+
+**Note:** When starting mesos_exporter in this mode, the process should run on the same node as the Mesos Slave it
+queries.
+
+##### Example
+
+    ./mesos_exporter -exporter.scrape-mode=slave -exporter.url=http://127.0.0.1:5051
 
 ### Docker
 


### PR DESCRIPTION
This PR adds support for scraping metrics exposed by a Mesos Master process.

It also introduces a change to the CLI flags by specifying `exporter.scrape-mode` to distinguish between the different modes that mesos_exporter supports. Also the different flags that included the term `url` have been unified into the flag `exporter.url`.

For now, I have added only those metrics also exposed by wndhydrnt/mesos-task-exporter (which I'd like to deprecate in favour of this repo) as these are the metrics I use every day.

Together with prometheus/prometheus#1027, these changes make it possible to monitor a Mesos cluster by running an instance of mesos_exporter next to a Mesos process.
