### PR TITLE
use the source field to match executors with their stats

### DIFF
--- a/main.go
+++ b/main.go
@@ -255,6 +255,7 @@ type slaveState struct {
 }
 
 type slaveStateExecutor struct {
+	Source string
 	Tasks []*slaveStateTask
 }
 
@@ -373,7 +374,7 @@ func (e *periodicExporter) fetch(urlChan <-chan string, metricsChan chan<- prome
 		for _, fw := range state.Frameworks {
 			for _, ex := range fw.Executors {
 				for _, t := range ex.Tasks {
-					taskInfo[t.ID] = exporterTaskInfo{fw.Name, t.Name}
+					taskInfo[ex.Source] = exporterTaskInfo{fw.Name, t.Name}
 				}
 			}
 		}


### PR DESCRIPTION
we are running mesos 0.23.0 with HubSpot's [Singularity Framework](https://github.com/HubSpot/Singularity), for some reason there were a handful of executors where the task id did not line up with the statistics' source field.  This fixed the problem for us.
