### PR TITLE
Remove needless use of MetricVec

### DIFF
--- a/main.go
+++ b/main.go
@@ -324,7 +324,7 @@ func (e *periodicExporter) Describe(ch chan<- *prometheus.Desc) {
 			ch <- m.Desc()
 		}
 	})
-	e.errors.MetricVec.Describe(ch)
+	e.errors.Describe(ch)
 }
 
 func (e *periodicExporter) Collect(ch chan<- prometheus.Metric) {
@@ -340,7 +340,7 @@ func (e *periodicExporter) Collect(ch chan<- prometheus.Metric) {
 			ch <- m
 		}
 	})
-	e.errors.MetricVec.Collect(ch)
+	e.errors.Collect(ch)
 }
 
 func (e *periodicExporter) fetch(urlChan <-chan string, metricsChan chan<- prometheus.Metric, wg *sync.WaitGroup) {


### PR DESCRIPTION
MetricVec is going to become unexported soon.

And only now I see it has been junkyarded... 

I'll simply merge to not create noise by people ho might still try to compile this...